### PR TITLE
Change not operator from "!" to "not"

### DIFF
--- a/interpit_test.lua
+++ b/interpit_test.lua
@@ -1026,7 +1026,7 @@ function test_expr(t)
 
     -- Print ! #1
     ast = {STMTxLIST, {PRINTxSTMT,
-      {{UNxOP, "!"}, {NUMLITxVAL, "5"}}}}
+      {{UNxOP, "not"}, {NUMLITxVAL, "5"}}}}
     input = {}
     statein = deepcopy(emptystate)
     expoutput = {"0"}
@@ -1036,7 +1036,7 @@ function test_expr(t)
 
     -- Print ! #2
     ast = {STMTxLIST, {PRINTxSTMT,
-      {{UNxOP, "!"}, {NUMLITxVAL, "0"}}}}
+      {{UNxOP, "not"}, {NUMLITxVAL, "0"}}}}
     input = {}
     statein = deepcopy(emptystate)
     expoutput = {"1"}


### PR DESCRIPTION
The expected output of the parser is "not" instead of "!"

From parseit_test.lua:1087
```lua
checkParse(t, "x=not not not not a", true, true,
      {STMTxLIST,{ASSNxSTMT,{SIMPLExVAR,"x"},{{UNxOP,"not"},{{UNxOP,"not"},
        {{UNxOP,"not"},{{UNxOP,"not"},{SIMPLExVAR,"a"}}}}}}},
      "Operator 'not' is right-associative")
```